### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+questionary
+requests
+cryptograpy
+termcolor


### PR DESCRIPTION
Creating a requirements.txt that contains the necessary packages needed to install. Then a venv can be used with pip3 install -r  requirements.txt.